### PR TITLE
Use C++ namespace wrappers for C stdlib includes

### DIFF
--- a/awsv4.hpp
+++ b/awsv4.hpp
@@ -1,8 +1,8 @@
 #ifndef AWSV4_HPP
 #define AWSV4_HPP
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include <stdexcept>
 #include <algorithm>


### PR DESCRIPTION
To import C stdlib functions into the std namespace (i.e. to call
std::strcpy instead of strcpy), you must use '#include <cfoo>' instead of
'#include <foo.h>'.

This patch is necessary to compile on RHEL7.